### PR TITLE
Added trailing slash to the rssurl variable.

### DIFF
--- a/rss.server.js
+++ b/rss.server.js
@@ -97,7 +97,7 @@ RssFeed = {
 
 // Handle the actual connection
 WebApp.connectHandlers.use(function(req, res, next) {
-  rssurl = /^\/rss/gi;
+  rssurl = /^\/rss\//gi;
 
   if (!rssurl.test(req.url)) {
     return next();


### PR DESCRIPTION
As far as I can see all feeds will be published with an url like `http://domain/rss/foo`. The check of the url of the request should include the trailing slash, so routes like `/rss` or `/rssfeed` are still useable in the meteor app.
